### PR TITLE
Override filetypes that already exist in filetype.vim

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,7 +17,7 @@ NeoBundleInstall ocaml/vim-ocaml'
 
 " or use NeoBundleLazy
 NeoBundleLazy 'rgrinberg/vim-ocaml', {'autoload' : {'filetypes' :
-    \ ['ocaml', 'ocamlinterface', 'dune', 'opam', 'oasis', 'omake', 'ocamlbuild_tags', 'sexplib']}}
+    \ ['ocaml', 'ocamlinterface', 'ocamllex', 'dune', 'opam', 'oasis', 'omake', 'ocamlbuild_tags', 'sexplib']}}
 ```
 
 ## History

--- a/README.md
+++ b/README.md
@@ -17,7 +17,7 @@ NeoBundleInstall ocaml/vim-ocaml'
 
 " or use NeoBundleLazy
 NeoBundleLazy 'rgrinberg/vim-ocaml', {'autoload' : {'filetypes' :
-    \ ['ocaml', 'dune', 'opam', 'oasis', 'omake', 'ocamlbuild_tags', 'sexplib']}}
+    \ ['ocaml', 'ocamlinterface', 'dune', 'opam', 'oasis', 'omake', 'ocamlbuild_tags', 'sexplib']}}
 ```
 
 ## History

--- a/README.md
+++ b/README.md
@@ -16,8 +16,9 @@ Plugin 'ocaml/vim-ocaml'
 NeoBundleInstall ocaml/vim-ocaml'
 
 " or use NeoBundleLazy
-NeoBundleLazy 'rgrinberg/vim-ocaml', {'autoload' : {'filetypes' :
-    \ ['ocaml', 'ocamlinterface', 'ocamllex', 'dune', 'opam', 'oasis', 'omake', 'ocamlbuild_tags', 'sexplib']}}
+NeoBundleLazy 'ocaml/vim-ocaml', {'autoload' : {'filetypes' : [
+    \ 'ocaml', 'ocamlinterface', 'ocamllex', 'menhir', 'dune', 'opam',
+    \ 'oasis', 'omake', 'ocamlbuild_tags', 'sexplib']}}
 ```
 
 ## History

--- a/ftdetect/menhir.vim
+++ b/ftdetect/menhir.vim
@@ -1,1 +1,1 @@
-au BufNewFile,BufRead *.mly setf menhir
+au BufNewFile,BufRead *.mly set ft=menhir

--- a/ftdetect/menhir.vim
+++ b/ftdetect/menhir.vim
@@ -1,0 +1,1 @@
+au BufNewFile,BufRead *.mly setf menhir

--- a/ftdetect/ocaml.vim
+++ b/ftdetect/ocaml.vim
@@ -1,1 +1,1 @@
-au BufNewFile,BufRead *.ml,*.mll,*.mly,.ocamlinit,*.mlt,*.mlp,*.ml.cppo setf ocaml
+au BufNewFile,BufRead *.ml,*.mly,.ocamlinit,*.mlt,*.mlp,*.ml.cppo setf ocaml

--- a/ftdetect/ocaml.vim
+++ b/ftdetect/ocaml.vim
@@ -1,1 +1,1 @@
-au BufNewFile,BufRead *.ml,*.mly,.ocamlinit,*.mlt,*.mlp,*.ml.cppo setf ocaml
+au BufNewFile,BufRead *.ml,.ocamlinit,*.mlt,*.mlp,*.ml.cppo setf ocaml

--- a/ftdetect/ocaml.vim
+++ b/ftdetect/ocaml.vim
@@ -1,1 +1,1 @@
-au BufNewFile,BufRead *.ml,*.mli,*.mll,*.mly,.ocamlinit,*.mlt,*.mlp,*.mlip,*.mli.cppo,*.ml.cppo setf ocaml
+au BufNewFile,BufRead *.ml,*.mll,*.mly,.ocamlinit,*.mlt,*.mlp,*.ml.cppo setf ocaml

--- a/ftdetect/ocamlinterface.vim
+++ b/ftdetect/ocamlinterface.vim
@@ -1,1 +1,1 @@
-au BufNewFile,BufRead *.mli,*.mlip,*.mli.cppo setf ocamlinterface
+au BufNewFile,BufRead *.mli,*.mlip,*.mli.cppo set ft=ocamlinterface

--- a/ftdetect/ocamlinterface.vim
+++ b/ftdetect/ocamlinterface.vim
@@ -1,0 +1,1 @@
+au BufNewFile,BufRead *.mli,*.mlip,*.mli.cppo setf ocamlinterface

--- a/ftdetect/ocamllex.vim
+++ b/ftdetect/ocamllex.vim
@@ -1,1 +1,1 @@
-au BufNewFile,BufRead *.mll setf ocamllex
+au BufNewFile,BufRead *.mll set ft=ocamllex

--- a/ftdetect/ocamllex.vim
+++ b/ftdetect/ocamllex.vim
@@ -1,0 +1,1 @@
+au BufNewFile,BufRead *.mll setf ocamllex

--- a/ftplugin/menhir.vim
+++ b/ftplugin/menhir.vim
@@ -1,0 +1,12 @@
+" Language:    Menhir
+" Maintainer:  vim-ocaml maintainers
+" URL:         http://www.github.com/ocaml/vim-ocaml
+
+if exists("b:did_ftplugin")
+  finish
+endif
+
+runtime! ftplugin/ocaml.vim
+runtime! ftplugin/ocaml_*.vim ftplugin/ocaml/*.vim
+
+" vim:sw=2 fdm=indent

--- a/ftplugin/ocamlinterface.vim
+++ b/ftplugin/ocamlinterface.vim
@@ -1,0 +1,12 @@
+" Language:    OCaml Interface
+" Maintainer:  vim-ocaml maintainers
+" URL:         http://www.github.com/ocaml/vim-ocaml
+
+if exists("b:did_ftplugin")
+  finish
+endif
+
+runtime! ftplugin/ocaml.vim
+runtime! ftplugin/ocaml_*.vim ftplugin/ocaml/*.vim
+
+" vim:sw=2 fdm=indent

--- a/ftplugin/ocamllex.vim
+++ b/ftplugin/ocamllex.vim
@@ -1,0 +1,12 @@
+" Language:    OCamlLex
+" Maintainer:  vim-ocaml maintainers
+" URL:         http://www.github.com/ocaml/vim-ocaml
+
+if exists("b:did_ftplugin")
+  finish
+endif
+
+runtime! ftplugin/ocaml.vim
+runtime! ftplugin/ocaml_*.vim ftplugin/ocaml/*.vim
+
+" vim:sw=2 fdm=indent


### PR DESCRIPTION
Some OCaml filetypes already exist in NeoVim's filetype.vim/filetype.lua.
`setf` only sets the filetype if it is not already set.
Because filetype.vim already set the filetype for *.mli/*.mll/*.mly and
is loaded before this ftdetect plugin we have to override it using `set ft`.

This is 'solution A' from https://neovim.io/doc/user/filetype.html#new-filetype

The other filetypes are either new, or match what is already declared in
filetype.vim so no need for overrides there.

See also my comment at https://github.com/ocaml/vim-ocaml/pull/61#issuecomment-1115440871